### PR TITLE
feat: dual-target — add legacy ovos-audio service entry point

### DIFF
--- a/ovos_media_plugin_vlc/__init__.py
+++ b/ovos_media_plugin_vlc/__init__.py
@@ -10,6 +10,16 @@ from ovos_utils.log import LOG
 class VlcBaseService(MediaBackend):
     def __init__(self, config, bus=None, video=False):
         super().__init__(config, bus)
+        self._init_vlc(config, bus, video=video)
+
+    def _init_vlc(self, config, bus=None, video=False):
+        """Set up the libvlc engine + event handlers.
+
+        Factored out of ``__init__`` so it can be shared by both the new
+        ``MediaBackend`` (ovos-media) backends and the legacy ``AudioBackend``
+        (ovos-audio) adapter, which have different base-class constructors but
+        drive the same VLC engine underneath.
+        """
         if video:
             self.instance = vlc.Instance("")
         else:

--- a/ovos_media_plugin_vlc/audio.py
+++ b/ovos_media_plugin_vlc/audio.py
@@ -1,0 +1,41 @@
+"""Legacy ``ovos-audio`` (mycroft.plugin.audioservice) adapter.
+
+The same VLC engine as the new ovos-media :class:`VLCOCPAudioService`, exposed
+under the legacy audio-service contract so this plugin works on both stacks:
+
+* new ``ovos-media`` — ``opm.media.audio`` → :class:`~ovos_media_plugin_vlc.VLCOCPAudioService`
+* legacy ``ovos-audio`` — ``mycroft.plugin.audioservice`` → :class:`VLCAudioService`
+  (discovered via :func:`load_service`)
+"""
+from ovos_plugin_manager.templates.audio import AudioBackend
+from ovos_utils.log import LOG
+
+from ovos_media_plugin_vlc import VlcBaseService
+
+
+class VLCAudioService(VlcBaseService, AudioBackend):
+    """VLC backend for the legacy ovos-audio service.
+
+    Reuses every playback method (``play``/``stop``/``pause``/``resume``/
+    seek/volume/track-info) from :class:`VlcBaseService`; only the constructor
+    differs because the legacy ``AudioBackend`` takes a ``name``.
+
+    ``VlcBaseService`` is listed first so its concrete methods satisfy the
+    abstract playback methods declared on ``AudioBackend`` (MRO order matters).
+    """
+
+    def __init__(self, config, bus=None, name='vlc'):
+        AudioBackend.__init__(self, config, bus, name)
+        # set up the VLC engine without the new MediaBackend constructor
+        self._init_vlc(config, bus, video=False)
+
+
+def load_service(base_config, bus):
+    backends = base_config.get('backends', {})
+    services = [(b, backends[b]) for b in backends
+                if backends[b].get('type') in ['vlc', 'ovos_vlc'] and
+                backends[b].get('active', True)]
+    instances = [VLCAudioService(s[1], bus, s[0]) for s in services]
+    if len(instances) == 0:
+        LOG.warning("No VLC backends have been configured")
+    return instances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ ovos-media-audio-plugin-vlc = "ovos_media_plugin_vlc:VLCOCPAudioService"
 [project.entry-points."opm.media.video"]
 ovos-media-video-plugin-vlc = "ovos_media_plugin_vlc:VLCOCPVideoService"
 
+# legacy ovos-audio service backend (so the plugin works on both stacks)
+[project.entry-points."mycroft.plugin.audioservice"]
+ovos_vlc = "ovos_media_plugin_vlc.audio"
+
 [tool.setuptools.dynamic]
 version = { attr = "ovos_media_plugin_vlc.version.__version__" }
 

--- a/test/unittests/test_backends.py
+++ b/test/unittests/test_backends.py
@@ -1,0 +1,85 @@
+"""Unit tests for the VLC backends.
+
+``python-vlc`` (and libvlc) are not available in CI, so ``vlc`` is mocked in
+``sys.modules`` before importing the plugin. The tests assert wiring/contract,
+not real playback: both the new ovos-media backends and the legacy ovos-audio
+adapter build, expose the right base classes, and the supported URIs + entry
+points are declared correctly.
+"""
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+
+# --- mock libvlc so the plugin imports without a real VLC install -----------
+_vlc = MagicMock()
+# vlc.EventType.* must be attribute-accessible; MagicMock handles that.
+sys.modules.setdefault("vlc", _vlc)
+
+from ovos_plugin_manager.templates.media import (
+    AudioPlayerBackend, VideoPlayerBackend)
+from ovos_plugin_manager.templates.audio import AudioBackend
+
+from ovos_media_plugin_vlc import (
+    VlcBaseService, VLCOCPAudioService, VLCOCPVideoService)
+from ovos_media_plugin_vlc.audio import VLCAudioService, load_service
+
+
+class TestNewBackends(unittest.TestCase):
+    def test_audio_backend_is_audioplayerbackend(self):
+        svc = VLCOCPAudioService({}, bus=MagicMock())
+        self.assertIsInstance(svc, AudioPlayerBackend)
+        self.assertIsInstance(svc, VlcBaseService)
+
+    def test_video_backend_is_videoplayerbackend(self):
+        svc = VLCOCPVideoService({}, bus=MagicMock())
+        self.assertIsInstance(svc, VideoPlayerBackend)
+
+    def test_supported_uris(self):
+        svc = VLCOCPAudioService({}, bus=MagicMock())
+        self.assertEqual(svc.supported_uris(), ['file', 'http', 'https'])
+
+
+class TestLegacyAdapter(unittest.TestCase):
+    def test_legacy_is_audiobackend(self):
+        svc = VLCAudioService({}, bus=MagicMock(), name='vlc')
+        self.assertIsInstance(svc, AudioBackend)
+        # reuses the shared VLC engine/methods
+        self.assertIsInstance(svc, VlcBaseService)
+        self.assertTrue(hasattr(svc, "play"))
+        self.assertTrue(hasattr(svc, "lower_volume"))
+
+    def test_supported_uris(self):
+        svc = VLCAudioService({}, bus=MagicMock(), name='vlc')
+        self.assertEqual(svc.supported_uris(), ['file', 'http', 'https'])
+
+    def test_load_service_builds_active_vlc_backends(self):
+        cfg = {"backends": {
+            "myvlc": {"type": "vlc", "active": True},
+            "off": {"type": "vlc", "active": False},
+            "other": {"type": "mpv", "active": True},
+        }}
+        services = load_service(cfg, bus=MagicMock())
+        self.assertEqual(len(services), 1)
+        self.assertIsInstance(services[0], VLCAudioService)
+
+    def test_load_service_empty(self):
+        self.assertEqual(load_service({"backends": {}}, bus=MagicMock()), [])
+
+
+class TestEntryPoints(unittest.TestCase):
+    """Both the new and legacy entry-point groups must be declared."""
+
+    def test_pyproject_declares_new_and_legacy_groups(self):
+        import os
+        here = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        with open(os.path.join(here, "pyproject.toml")) as f:
+            src = f.read()
+        self.assertIn("opm.media.audio", src)
+        self.assertIn("opm.media.video", src)
+        self.assertIn("mycroft.plugin.audioservice", src)
+        self.assertIn("ovos_media_plugin_vlc.audio", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Makes the VLC plugin usable on **both** stacks:

- **new (ovos-media):** `opm.media.audio` / `opm.media.video` → `VLCOCPAudioService` / `VLCOCPVideoService`
- **legacy (ovos-audio):** `mycroft.plugin.audioservice` → `ovos_media_plugin_vlc.audio` (`load_service`)

The VLC engine setup is factored into `VlcBaseService._init_vlc` so the new `MediaBackend` backends and the legacy `AudioBackend` adapter (`VLCAudioService`) drive one shared engine — no duplicated playback logic. Follows the established ffplay dual-entry-point pattern.

Replaces the placeholder unittest with real contract tests (libvlc mocked): both new backends + the legacy adapter instantiate, expose the correct base classes and supported URIs, `load_service` filters active vlc backends, and all three entry-point groups are declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)