### PR TITLE
test: end-to-end test via ovoscope OCPPlayerHarness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
+    # end-to-end harness: drives the real backend through a real OCPMediaPlayer.
+    # [media] (the OCPPlayerHarness) lands in ovoscope 0.20.x; floor-pin so pip
+    # resolves it without --pre once published.
+    "ovoscope[media]>=0.20.0a1",
 ]
 
 [project.urls]

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -1,0 +1,69 @@
+"""End-to-end tests: drive the real VLC OCP backend through a real
+``OCPMediaPlayer`` on a FakeBus via ovoscope's media harness.
+
+The VLC *engine* (libvlc via the ``vlc`` module) is mocked so no real
+player/binary is needed, but everything else is real: the OCP player routes the
+play/pause/stop/seek requests to ``VLCOCPAudioService`` exactly as ovos-media
+would at runtime.
+
+Requires ``ovoscope[media]`` (pulls ovos-media).
+"""
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    from ovoscope import OCPPlayerHarness
+    from ovos_utils.ocp import MediaEntry, PlaybackType, PlayerState
+    HAVE_HARNESS = True
+except Exception:
+    HAVE_HARNESS = False
+
+# libvlc bindings (``python-vlc``) are an optional native dep; stub the module
+# so the plugin imports without the real engine. The per-test ``patch`` below
+# still owns the engine while playback is driven.
+sys.modules.setdefault("vlc", MagicMock())
+
+import ovos_media_plugin_vlc
+from ovos_media_plugin_vlc import VLCOCPAudioService
+
+URI = "http://example.com/song.mp3"
+
+
+def _factory(bus):
+    """Build the real VLC audio backend for injection into the OCP player."""
+    return VLCOCPAudioService({}, bus)
+
+
+@unittest.skipUnless(HAVE_HARNESS, "ovoscope[media] not installed")
+class TestVLCEndToEnd(unittest.TestCase):
+    def test_play_pause_resume_stop_through_ocp(self):
+        with patch.object(ovos_media_plugin_vlc, "vlc", MagicMock()):
+            with OCPPlayerHarness(backend_factory=_factory) as h:
+                entry = MediaEntry(uri=URI, playback=PlaybackType.AUDIO)
+
+                h.play(entry)
+                h.assert_player_state(PlayerState.PLAYING)
+                h.assert_now_playing_uri(URI)
+                # the real backend actually started its (mocked) vlc engine
+                self.assertIsNotNone(h.backend.player)
+
+                h.pause()
+                h.assert_player_state(PlayerState.PAUSED)
+
+                h.resume()
+                h.assert_player_state(PlayerState.PLAYING)
+
+                h.stop()
+                h.assert_player_state(PlayerState.STOPPED)
+
+    def test_backend_is_the_real_vlc_plugin(self):
+        with patch.object(ovos_media_plugin_vlc, "vlc", MagicMock()):
+            with OCPPlayerHarness(backend_factory=_factory) as h:
+                self.assertIsInstance(h.backend, VLCOCPAudioService)
+                self.assertEqual(h.backend.supported_uris(),
+                                 ["file", "http", "https"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Drive the real `VLCOCPAudioService` through a real ovos-media `OCPMediaPlayer` on a FakeBus via ovoscope's `OCPPlayerHarness`, exercising the full play/pause/resume/stop flow + now_playing routing. The libvlc engine is mocked so no real player runs.

Declares the `ovoscope[media]>=0.20.0a1` test extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)